### PR TITLE
Ensure SetTransactionStatus uses passed transaction item

### DIFF
--- a/Golden_Template/Framework/SetTransactionStatus.xaml
+++ b/Golden_Template/Framework/SetTransactionStatus.xaml
@@ -11,11 +11,6 @@
     <x:Property sap2010:Annotation.AnnotationText="Used during transitions between states to represent exceptions other than business exceptions." Name="in_SystemException" Type="InArgument(s:Exception)" />
     <x:Property sap2010:Annotation.AnnotationText="Used to control the number of consecutive system exceptions." Name="io_ConsecutiveSystemExceptions" Type="InOutArgument(x:Int32)" />
   </x:Members>
-  <this:SetTransactionStatus.in_TransactionItem>
-    <InArgument x:TypeArguments="ui:QueueItem">
-      <CSharpValue x:TypeArguments="ui:QueueItem" sap2010:WorkflowViewState.IdRef="CSharpValue`1_1">null</CSharpValue>
-    </InArgument>
-  </this:SetTransactionStatus.in_TransactionItem>
   <sap2010:ExpressionActivityEditor.ExpressionActivityEditor>C#</sap2010:ExpressionActivityEditor.ExpressionActivityEditor>
   <sap:VirtualizedContainerService.HintSize>712,1304.6666666666667</sap:VirtualizedContainerService.HintSize>
   <sap2010:WorkflowViewState.IdRef>ActivityBuilder_1</sap2010:WorkflowViewState.IdRef>


### PR DESCRIPTION
## Summary
- Remove null assignment for `in_TransactionItem` in `SetTransactionStatus.xaml` so passed arguments are preserved

## Testing
- `xmllint --noout Golden_Template/Framework/SetTransactionStatus.xaml`


------
https://chatgpt.com/codex/tasks/task_e_68923b7e4a2c8331887424d0b42e5318